### PR TITLE
Crit command refactor and only retrieves submissions not by the user or not having had feedback from the user

### DIFF
--- a/cogs/member.py
+++ b/cogs/member.py
@@ -48,7 +48,10 @@ class Member(commands.Cog):
             await ctx.author.send("Invalid input please see `!help` for usage")
             return
 
-        submission_list = _db.get_ordered_queue_submissions()
+        user = _db.get_user_by_author_id(ctx.author.id)
+        submission_list = _db.get_ordered_queue_submissions(
+            not_user_id=user.user_id, check_user_feedback_id=user.user_id
+        )
 
         if submission_list is None:
             await ctx.author.send("You have reviewed all avialable submissions")

--- a/cogs/member.py
+++ b/cogs/member.py
@@ -36,16 +36,38 @@ class Member(commands.Cog):
         )
 
     @commands.command(
-        name="critRandom", help="Returns a random submission from the queue"
+        name="crit", help="Returns the next or a random submission from the queue"
     )
-    async def get_crit_random(self, ctx):
-        # Crit Random
-        submission_list = _db.get_ordered_queue_submissions()
-        submissions_with_positions = _db.get_submission_positions_in_queue_multi(submission_list)
+    async def get_crit(self, ctx, arg="next"):
+        # Crit
+        arg = arg.lower()
+        
+        valid_args = ["next", "random"]
 
-        sub_pos = random.choice(submissions_with_positions)
+        if arg not in valid_args:
+            await ctx.author.send("Invalid input please see `!help` for usage")
+            return
+
+        submission_list = _db.get_ordered_queue_submissions()
+
+        if submission_list is None:
+            await ctx.author.send("You have reviewed all avialable submissions")
+            return
+
+        submissions_with_positions = _db.get_submission_positions_in_queue_multi(
+            submission_list
+        )
+
+        if arg == "next":
+            review_text = "Submission to Review:\n"
+            sub_pos = submissions_with_positions[0]
+
+        elif arg == "random":
+            review_text = "Random submission to review:\n"
+            sub_pos = random.choice(submissions_with_positions)
+            
         text = (
-                "Random submission to review:\n"
+            review_text
                 + "Submission #"
                 + str(sub_pos[1])
                 + "\n"

--- a/services/db_service.py
+++ b/services/db_service.py
@@ -50,8 +50,24 @@ def get_submissions_by_user_id(user_id):
         return ListDictToObj(list(submissions))
 
 
-def get_ordered_queue_submissions():
-    submissions = db.submissions.find({'status': 'pending'}).sort([("created_at", 1)])
+def get_ordered_queue_submissions(not_user_id=None, check_user_feedback_id=None):
+
+    message_ids = []
+
+    if check_user_feedback_id is not None:
+        feedback = get_feedbacks_given(check_user_feedback_id)
+
+        if feedback is not None:
+            message_ids = [entry.submission_id for entry in feedback]
+
+    submissions = db.submissions.find(
+        {
+            "status": "pending",
+            "user_id": {"$ne": not_user_id},
+            "message_id": {"$nin": message_ids},
+        }
+    ).sort([("created_at", 1)])
+    
     if submissions.count() < 1:
         return None
     else:


### PR DESCRIPTION
Refactor the `!critRandom` command into `!crit next` and `!crit random` 

Adds optional arguments `not_user_id` and `check_user_feedback_id` to `get_ordered_queue_submissions` 

this allows the retrieval of the most relevant submissions to the users of `!crit`

Closes #6 
Closes #13 